### PR TITLE
Remove manual inclusion of CMAKE_CURRENT_{SOURCE,BINARY}_DIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,8 +25,6 @@ zeek_add_plugin(
     Zeek
     Cluster_Backend_NATS
     INCLUDE_DIRS
-    ${CMAKE_CURRENT_SOURCE_DIR}
-    ${CMAKE_CURRENT_BINARY_DIR}
     ${LIBNATS_INCLUDE_DIRS}
     DEPENDENCIES
     ${LIBNATS_LIBRARIES}


### PR DESCRIPTION
Including these isn't necessary as the zeek plugin CMake API does what is necessary to include these paths. This also fixes a bunch of warnings where make thinks the `VERSION` file is a valid file to include, and conflicts with C++'s `<version>` header in C++ 20 and above.